### PR TITLE
add fcommon flag

### DIFF
--- a/ext/vacman_controller/extconf.rb
+++ b/ext/vacman_controller/extconf.rb
@@ -13,7 +13,7 @@ else
   exit 1
 end
 
-append_cflags "-I#{VACMAN_CONTROLLER}/include -Wall -std=c99 -Wno-declaration-after-statement"
+append_cflags "-I#{VACMAN_CONTROLLER}/include -fcommon -Wall -std=c99 -Wno-declaration-after-statement"
 append_ldflags "-L#{VACMAN_CONTROLLER}/lib -laal2sdk -Wl,-rpath #{VACMAN_CONTROLLER}/lib"
 
 if find_library('aal2sdk', 'AAL2DPXInit', "#{VACMAN_CONTROLLER}/lib")

--- a/lib/vacman_controller/version.rb
+++ b/lib/vacman_controller/version.rb
@@ -1,3 +1,3 @@
 module VacmanController
-  VERSION = '0.9.2'
+  VERSION = '0.9.3'
 end


### PR DESCRIPTION
Newer versions of gcc are more strict with compilation, and assume `-fno-common` flag, which breaks build of this gem, due to duplicate definitions in `vacman_controller.h`. This patch force old behavior by pasing `-fcommon` back.