### PR TITLE
Opt-in for MFA requirement

### DIFF
--- a/vacman_controller.gemspec
+++ b/vacman_controller.gemspec
@@ -18,4 +18,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'byebug'
   s.add_development_dependency 'code_counter'
+
+  s.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
Make the gem more secure by requiring that all privileged operations by any of the owners require OTP.

Ref: https://guides.rubygems.org/mfa-requirement-opt-in/